### PR TITLE
Fix sidebar icon color

### DIFF
--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -1,6 +1,6 @@
 <h3 class="flex items-center font-normal text-white mb-6 text-base no-underline">
 	<svg class="sidebar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-        <path fill="#B3C1D1" d="M12.26 11.74L10 14H8v2H6v2l-2 2H0v-4l8.26-8.26a6 6 0 1 1 4 4zm4.86-4.62A3 3 0 0 0 15 2a3 3 0 0 0-2.12.88l4.24 4.24z"/>
+        <path fill="var(--sidebar-icon)" d="M12.26 11.74L10 14H8v2H6v2l-2 2H0v-4l8.26-8.26a6 6 0 1 1 4 4zm4.86-4.62A3 3 0 0 0 15 2a3 3 0 0 0-2.12.88l4.24 4.24z"/>
     </svg>
 	<span class="sidebar-label">
 		@lang('novassport::navigation.sidebar-label')


### PR DESCRIPTION
Hey,

So I've altered my nova colors and noticed that the icon did was still grey 
![current](https://user-images.githubusercontent.com/1488300/63837479-da2c2f80-c97b-11e9-88f3-9adb675f09c3.png)

Nova uses a variable `var(--sidebar-icon)` allowing users to alter colors.
By applying this value for fill the icon takes the color set by the user:
![new](https://user-images.githubusercontent.com/1488300/63837565-fcbe4880-c97b-11e9-8889-535b3c312f82.png)

Thanks for the package :)

Cheers,
RJ