### PR TITLE
Added Laravel 6.0 and Laravel Nova 2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Depending on your version of Laravel, you should install a different version of 
 
 | Laravel Version | Package Version |
 |:---------------:|:---------------:|
-|       6.0       |      soon..     |
+|       6.0       |      2.0        |
 |       5.8       |      1.0        |
 
 You can install the Nova tool in to a [Laravel](http://laravel.com) app that uses [Nova](http://nova.laravel.com) via composer :

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ohysdev/novassport",
+    "name": "kristories/novassport",
     "description": "A Laravel Nova tool to manage API Authentication (Passport).",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kristories/novassport",
+    "name": "ohysdev/novassport",
     "description": "A Laravel Nova tool to manage API Authentication (Passport).",
     "keywords": [
         "laravel",
@@ -13,8 +13,8 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "laravel/nova": "^1.0",
-        "laravel/framework": "^5.8"
+        "laravel/nova": "^2.0",
+        "laravel/framework": "^6.0"
     },
     "repositories": [
         {

--- a/src/Observers/OauthClientObserver.php
+++ b/src/Observers/OauthClientObserver.php
@@ -2,7 +2,7 @@
 
 namespace Kristories\Novassport\Observers;
 
-use Auth;
+use Auth, Str;
 use Kristories\Novassport\Models\OauthClient;
 
 class OauthClientObserver
@@ -16,7 +16,7 @@ class OauthClientObserver
     public function creating(OauthClient $client)
     {
         $client->user_id                = Auth::id();
-        $client->secret                 = str_random(40);
+        $client->secret                 = Str::random(40);
         $client->revoked                = false;
         $client->personal_access_client = false;
         $client->password_client        = false;


### PR DESCRIPTION
str_random() is replaced by Str::random(). str_random() was deprecated after Laravel 5.8. No other problem was found.